### PR TITLE
Remove unneeded free

### DIFF
--- a/src/jvl/mediaformat/MediaFormatParserPlugin.java
+++ b/src/jvl/mediaformat/MediaFormatParserPlugin.java
@@ -194,7 +194,6 @@ public class MediaFormatParserPlugin implements sage.media.format.FormatParserPl
                             format.addMetadata("ThumbnailSize", picture.getSize() + "");
                             if(isDebug) System.out.println("\tThumbnailOffset: " +  picture.getPosition() );
                             format.addMetadata("ThumbnailOffset", picture.getPosition() + "");
-                            picture.free();
                         }
                          
                     }


### PR DESCRIPTION
This free isn't needed and causes a crash on Linux when parsing audio files with cover images (like .m4a files).

The underlying `picture` struct is part of the `avformat` struct created/allocated when `AVFormatContext.buildAVFormatInputContext` is called and will be freed automatically when `avformat.close()` (which calls `Java_jvl_FFmpeg_jni_AVFormatContext_closeInput`) is called.